### PR TITLE
Lawgiver: map manage footer permission to "manage footer" action group.

### DIFF
--- a/ftw/footer/lawgiver.zcml
+++ b/ftw/footer/lawgiver.zcml
@@ -5,8 +5,8 @@
 
     <include package="ftw.lawgiver" file="meta.zcml" />
 
-
-    <lawgiver:ignore
+    <lawgiver:map_permissions
+        action_group="manage footer"
         permissions="ftw.footer: Manage Footer"
         />
 


### PR DESCRIPTION
The manage footer permission should be manageable by lawgiver workflows.
Therefore I remapped the permission to the **manage footer** action group.
