### PR TITLE
Do not redirect to manage-footer view after modifying regular portlet managers.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not redirect to manage-footer view after modifying regular portlet
+  managers.
+  [mathias.leimgruber]
 
 
 1.0.1 (2014-12-02)

--- a/ftw/footer/manage.py
+++ b/ftw/footer/manage.py
@@ -27,7 +27,10 @@ class CustomManageContextualPortlets(ManageContextualPortlets):
             getMultiAdapter((self.context, self.request), name='absolute_url')
         )
 
-        # This is the part we need to override from the parent class.
-        self.request.response.redirect(base_url + '/manage-footer')
+        if self.request.get('HTTP_REFERER', '').endswith('manage-footer'):
+            # This is the part we need to override from the parent class.
+            self.request.response.redirect(base_url + '/manage-footer')
+        else:
+            self.request.response.redirect(base_url + '/@@manage-portlets')
 
         return ''


### PR DESCRIPTION
Unfortunately I'm not able to test this. 
In a functional test the manage-footer's column provides renders always empty. 
