### PR TITLE
Link color is not visible on the footers background color.

### DIFF
--- a/ftw/footer/browser/resources/scss/footer.scss
+++ b/ftw/footer/browser/resources/scss/footer.scss
@@ -22,6 +22,11 @@ $footer-background-color: $color-secondary !default;
   float: none;
   padding-top: $padding-vertical * 12;
 
+  .portletWrapper {
+    border-bottom: 0;
+    padding-bottom: 0;
+  }
+
   .portlet {
     @include reset-definition-list();
   }

--- a/ftw/footer/browser/resources/scss/footer.scss
+++ b/ftw/footer/browser/resources/scss/footer.scss
@@ -6,6 +6,13 @@ $footer-background-color: $color-secondary !default;
   @include clearfix;
   background: $footer-background-color;
   margin-top: -$padding-vertical * 10;
+
+  a {
+    color: $color-link-inverted;
+    &:hover {
+      color: $color-link-hover-inverted;
+    }
+  }
 }
 
 #columns {


### PR DESCRIPTION
Depends on https://github.com/4teamwork/ftw.theming/pull/34

Apply the `color-link-inverted` color to the footer to have more contrast because the footer has a background color.

Ersigen as an example:

![bildschirmfoto 2016-02-15 um 11 50 36](https://cloud.githubusercontent.com/assets/1637820/13046661/5b45a646-d3da-11e5-8ed4-04475e9bc0f6.png)

