### PR TITLE
Remove border on footer portlets.

### DIFF
--- a/ftw/footer/browser/resources/scss/footer.scss
+++ b/ftw/footer/browser/resources/scss/footer.scss
@@ -29,7 +29,7 @@ $footer-background-color: $color-secondary !default;
   float: none;
   padding-top: $padding-vertical * 12;
 
-  .portletWrapper {
+  .portlet {
     border-bottom: 0;
     padding-bottom: 0;
   }


### PR DESCRIPTION
Because of https://github.com/4teamwork/plonetheme.blueberry/pull/59
the border and spacing assignemts are set to `.portlet` instead of
`.portletWrapper` so we have to disable the border on `.portlet`.