### PR TITLE
Enable the footer on non-contentish items.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Enable the footer on non-contentish items.
+  [lknoepfel]
 
 
 1.1.1 (2016-05-20)

--- a/ftw/footer/configure.zcml
+++ b/ftw/footer/configure.zcml
@@ -21,16 +21,7 @@
 
 
     <browser:viewlet
-        for="Products.CMFCore.interfaces.IContentish"
-        name="ftw.footer.viewlet"
-        manager="plone.app.layout.viewlets.interfaces.IPortalFooter"
-        class=".footer_viewlet.FooterViewlet"
-        permission="zope2.View"
-        layer="ftw.footer.interfaces.IFtwFooterLayer"
-        />
-
-    <browser:viewlet
-        for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+        for="*"
         name="ftw.footer.viewlet"
         manager="plone.app.layout.viewlets.interfaces.IPortalFooter"
         class=".footer_viewlet.FooterViewlet"

--- a/ftw/footer/footer_viewlet.py
+++ b/ftw/footer/footer_viewlet.py
@@ -1,9 +1,12 @@
 from AccessControl import getSecurityManager
+from Acquisition._Acquisition import aq_parent
 from ftw.footer.interfaces import IFooterSettings
 from plone.app.layout.viewlets import common
 from plone.portlets.interfaces import IPortletAssignmentMapping
 from plone.portlets.interfaces import IPortletManager
 from plone.registry.interfaces import IRegistry
+from Products.CMFCore.interfaces import IContentish
+from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import getMultiAdapter
 from zope.component import getUtility
@@ -15,6 +18,15 @@ GRIDROWS = 16  # This should be configurable thru registry
 class FooterViewlet(common.ViewletBase):
 
         index = ViewPageTemplateFile('footer_viewlet.pt')
+
+        def __init__(self, context, request, view, manager=None):
+            super(FooterViewlet, self).__init__(context, request, view, manager)
+
+            # Set context to closest content to adapt the assignment mapping.
+            self.context = context
+            while not IContentish.providedBy(self.context) and \
+                    not IPloneSiteRoot.providedBy(self.context):
+                self.context = aq_parent(self.context)
 
         def calculate_width(self):
             columns = self.get_column_count()

--- a/ftw/footer/testing.py
+++ b/ftw/footer/testing.py
@@ -1,8 +1,11 @@
+from ftw.builder.testing import BUILDER_LAYER
+from ftw.builder.testing import functional_session_factory
+from ftw.builder.testing import set_builder_session_factory
+from plone.app.testing import applyProfile
+from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
-from ftw.builder.testing import BUILDER_LAYER
 from plone.app.testing import PloneSandboxLayer
-from plone.app.testing import applyProfile
 from plone.testing import z2
 from zope.configuration import xmlconfig
 
@@ -12,11 +15,19 @@ class FtwFooterLayer(PloneSandboxLayer):
     defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
 
     def setUpZope(self, app, configurationContext):
+        xmlconfig.string(
+            '<configure xmlns="http://namespaces.zope.org/zope">'
+            '  <include package="z3c.autoinclude" file="meta.zcml" />'
+            '  <includePlugins package="plone" />'
+            '  <includePluginsOverrides package="plone" />'
+            '</configure>',
+            context=configurationContext)
         # Load ZCML
         import ftw.footer
 
         xmlconfig.file('configure.zcml', ftw.footer,
                        context=configurationContext)
+
         z2.installProduct(app, 'ftw.footer')
 
     def setUpPloneSite(self, portal):
@@ -26,3 +37,8 @@ class FtwFooterLayer(PloneSandboxLayer):
 FTW_FOOTER_FIXTURE = FtwFooterLayer()
 FTW_FOOTER_INTEGRATION_TESTING = IntegrationTesting(
     bases=(FTW_FOOTER_FIXTURE, ), name="FtwFooter:Integration")
+
+FTW_FOOTER_FUNCTIONAL_TESTING = FunctionalTesting(
+    bases=(FTW_FOOTER_FIXTURE,
+           set_builder_session_factory(functional_session_factory)),
+    name="FtwFooter:Functional")

--- a/ftw/footer/tests/test_footer_functional.py
+++ b/ftw/footer/tests/test_footer_functional.py
@@ -1,0 +1,34 @@
+from ftw.footer.testing import FTW_FOOTER_FUNCTIONAL_TESTING
+from ftw.testbrowser import browsing
+from ftw.testbrowser.exceptions import HTTPServerError
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from unittest import TestCase
+import transaction
+
+
+class TestFooterFunctional(TestCase):
+
+    layer = FTW_FOOTER_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        super(TestFooterFunctional, self).setUp()
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        transaction.commit()
+
+    @browsing
+    def test_footer_on_non_contentish_object(self, browser):
+        # This tests checks tests if the footer is rendered on non contentish
+        # objects. For instance the view on an address portlet.
+        browser.login().open(
+            self.portal,
+            {':action': "/++contextportlets++ftw.footer.column1/"
+                        "+/plone.portlet.static.Static"})
+        browser.fill({'Text The text to render': 'Blubber'}).submit()
+
+        browser.open('http://nohost/plone/++contextportlets++'
+                     'ftw.footer.column1/portlet_static/edit')
+        self.assertEqual(
+            'Blubber',
+            browser.css('#footer-column-1 .portletItem').first.text)

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ maintainer = 'Mathias Leimgruber'
 tests_require = [
     'plone.app.testing',
     'ftw.builder',
+    'ftw.testbrowser',
     'pyquery',
     'unittest2',
     ]


### PR DESCRIPTION
The current footer is registered on `IPloneSiteRoot` and `IContentish`. But there are non-IContentish objects which can have a view. For example the address portlet on winterthur. The footer is not rendered there.

This PR changes the registration to `*`. And since it still needs an `IContentish` context for the `IPortletAssignmentMapping` the view now walks the aquisition until it finds a suited context.

Extranet Ticket: https://extranet.4teamwork.ch/support/stadt-winterthur/tracker-web/10