### PR TITLE
Remove CSS rule for #columns

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,8 +4,10 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Remove CSS rule for #columns which was creating a new stacking context
+  Looks like it was unnecessary for ftw.footer anyway.
+  Fixes https://github.com/4teamwork/izug.organisation/issues/1762
+  [djowett-ftw]
 
 1.2.0 (2019-09-12)
 ------------------

--- a/ftw/footer/browser/resources/scss/footer.scss
+++ b/ftw/footer/browser/resources/scss/footer.scss
@@ -15,11 +15,6 @@ $footer-background-color: $color-secondary !default;
   }
 }
 
-#columns {
-  position: relative;
-  z-index: 1;
-}
-
 #ftw-footer {
   @include row;
   @include auto-text-color($footer-background-color);


### PR DESCRIPTION
     ... which was creating a new stacking context

     Looks like it was unnecessary for ftw.footer anyway.
     Fixes https://github.com/4teamwork/izug.organisation/issues/1762

Note: The rule removed appears to do nothing and the original author of it can't remember anything different, but there is a small risk we are breaking something I didn't spot.